### PR TITLE
The sentry logger has been updated and a minor fix for enabling/disabling

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -31,8 +31,8 @@ if not mute_logs:
     from . import custom_logging  # pylint: disable=relative-import
 
     SENTRY_URL = (
-        'http://b257c02328384628a50de20d257cf06e:'
-        'ab515d8c88b746d484351321b0111b44@sentry.linfiniti.com/10')
+        'http://8a67c7961c844500a25d7dfd048c4da9:'
+        'de927b27fe5342dbb358accd031661ad@sentry.kartoza.com/31')
     custom_logging.setup_logger(SENTRY_URL)
 
 

--- a/custom_logging.py
+++ b/custom_logging.py
@@ -23,7 +23,7 @@ from datetime import date
 import getpass
 from tempfile import mkstemp
 
-from qgis.PyQt import QtCore
+from qgis.core import QgsSettings
 
 third_party_path = os.path.abspath(
     os.path.join(os.path.dirname(__file__), 'third_party'))
@@ -157,9 +157,9 @@ def setup_logger(sentry_url, log_file=None):
     # logging messages will be sent to the sentry host.
     # We will only log exceptions. You need to either:
     #  * Set env var 'SENTRY' present (value can be anything)
-    #  * Enable the 'plugins/use_sentry' QSettings option
+    #  * Enable the 'plugins/use_sentry' QgsSettings option
     # before this will be enabled.
-    settings = QtCore.QSettings()
+    settings = QgsSettings()
     flag = settings.value('stream-feature-extractor/sentry-logging', False)
 
     # This test is done because the setting for the value is string sometimes

--- a/custom_logging.py
+++ b/custom_logging.py
@@ -155,9 +155,8 @@ def setup_logger(sentry_url, log_file=None):
     # Sentry handler - this is optional hence the localised import
     # It will only log if pip install raven. If raven is available
     # logging messages will be sent to the sentry host.
-    # We will only log exceptions. You need to either:
-    #  * Set env var 'SENTRY' present (value can be anything)
-    #  * Enable the 'plugins/use_sentry' QgsSettings option
+    # We will only log exceptions.
+    # Enable the 'plugins/use_sentry' QgsSettings option
     # before this will be enabled.
     settings = QgsSettings()
     flag = settings.value(key='stream-feature-extractor/sentry-logging', defaultValue=False, type=bool)

--- a/custom_logging.py
+++ b/custom_logging.py
@@ -160,32 +160,18 @@ def setup_logger(sentry_url, log_file=None):
     #  * Enable the 'plugins/use_sentry' QgsSettings option
     # before this will be enabled.
     settings = QgsSettings()
-    flag = settings.value('stream-feature-extractor/sentry-logging', False)
+    flag = settings.value(key='stream-feature-extractor/sentry-logging', defaultValue=False, type=bool)
 
-    # This test is done because the setting for the value is string sometimes
-    # This happens when the setting was set from the plugin options dialog
-    if type(flag) is bool:
-        # Setting is of type boolean
-        if flag:
-            client = Client(sentry_url)
-            sentry_handler = SentryHandler(client)
-            sentry_handler.setFormatter(formatter)
-            sentry_handler.setLevel(logging.ERROR)
-            if add_logging_handler_once(logger, sentry_handler):
-                logger.debug('Sentry logging enabled')
-        else:
-            logger.debug('Sentry logging disabled')
+    if flag:
+        client = Client(sentry_url)
+        sentry_handler = SentryHandler(client)
+        sentry_handler.setFormatter(formatter)
+        sentry_handler.setLevel(logging.ERROR)
+        if add_logging_handler_once(logger, sentry_handler):
+            logger.debug('Sentry logging enabled')
     else:
-        # Setting is stored as a string
-        if flag.lower() == "true":
-            client = Client(sentry_url)
-            sentry_handler = SentryHandler(client)
-            sentry_handler.setFormatter(formatter)
-            sentry_handler.setLevel(logging.ERROR)
-            if add_logging_handler_once(logger, sentry_handler):
-                logger.debug('Sentry logging enabled')
-        else:
-            logger.debug('Sentry logging disabled')
+        logger.debug('Sentry logging disabled')
+
     # Set formatters
     file_handler.setFormatter(formatter)
     console_handler.setFormatter(formatter)

--- a/custom_logging.py
+++ b/custom_logging.py
@@ -161,15 +161,31 @@ def setup_logger(sentry_url, log_file=None):
     # before this will be enabled.
     settings = QtCore.QSettings()
     flag = settings.value('stream-feature-extractor/sentry-logging', False)
-    if 'SENTRY' in os.environ or flag:
-        client = Client(sentry_url)
-        sentry_handler = SentryHandler(client)
-        sentry_handler.setFormatter(formatter)
-        sentry_handler.setLevel(logging.ERROR)
-        if add_logging_handler_once(logger, sentry_handler):
-            logger.debug('Sentry logging enabled')
+
+    # This test is done because the setting for the value is string sometimes
+    # This happens when the setting was set from the plugin options dialog
+    if type(flag) is bool:
+        # Setting is of type boolean
+        if flag:
+            client = Client(sentry_url)
+            sentry_handler = SentryHandler(client)
+            sentry_handler.setFormatter(formatter)
+            sentry_handler.setLevel(logging.ERROR)
+            if add_logging_handler_once(logger, sentry_handler):
+                logger.debug('Sentry logging enabled')
+        else:
+            logger.debug('Sentry logging disabled')
     else:
-        logger.debug('Sentry logging disabled')
+        # Setting is stored as a string
+        if flag.lower() == "true":
+            client = Client(sentry_url)
+            sentry_handler = SentryHandler(client)
+            sentry_handler.setFormatter(formatter)
+            sentry_handler.setLevel(logging.ERROR)
+            if add_logging_handler_once(logger, sentry_handler):
+                logger.debug('Sentry logging enabled')
+        else:
+            logger.debug('Sentry logging disabled')
     # Set formatters
     file_handler.setFormatter(formatter)
     console_handler.setFormatter(formatter)


### PR DESCRIPTION
The sentry logger's URLs has been updated and now correctly logs to the sentry site.
A bug were fixed where error submitting will always occur, even when the user has disabled it in the options dialog. This were a result of instances stored a string and not a boolean for the setting, which broke the if-statement.